### PR TITLE
escaping file names more aggressively

### DIFF
--- a/panopto/panopto_downloader.py
+++ b/panopto/panopto_downloader.py
@@ -4,6 +4,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from slugify import slugify
+
 from panopto.panopto_folders import PanoptoFolders
 from panopto.panopto_sessions import PanoptoSessions
 from panopto.panopto_oauth2 import PanoptoOAuth2
@@ -85,7 +87,7 @@ class PanoptoDownloader:
             logging.info(f"Downloading session: {s['Name']} ({session_count} of {len(session_list)})")  # noqa: E501
             logging.debug(f"Session's download URL: {download_url}")
 
-            full_path = os.path.join(path, s['Name'] + '.mp4')
+            full_path = os.path.join(path, slugify(s['Name']) + '.mp4')
             try:
                 await self.panopto_sessions.download_session(download_url,
                                                              full_path,

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ typing_extensions==4.12.2
 uritemplate==4.1.1
 urllib3==2.2.3
 yarl==1.17.2
+python-slugify==8.0.4


### PR DESCRIPTION
This PR aggressively escapes downloaded file names using the `python-slugify` package